### PR TITLE
Fixed the bug noted in acceptance of last patch

### DIFF
--- a/js/directory.js
+++ b/js/directory.js
@@ -32,6 +32,7 @@ function getMatches(string) {
   bestMatchValue = 0;
   var terms = string.split(" ");
   for (var i = 0; i < terms.length; i++) {
+    if (terms[i] == "") continue;
     findByName(terms[i]);
     findByKerb(terms[i]);
     findByRoom(terms[i]);


### PR DESCRIPTION
Problem was that searching ' ' created '' terms which matched the rooms of people who have no rooms (like Nika).  Just patching the findByRoom function caused searching ' ' to return everyone in the everyone array, so I just made it ignore '' terms altogether.
